### PR TITLE
Update GPT models in preset list

### DIFF
--- a/src/ui/RequestBuilder.cpp
+++ b/src/ui/RequestBuilder.cpp
@@ -161,7 +161,7 @@ RequestBuilder::RequestBuilder(url_source_request_data *request_data,
 			/* ------------------------------------------- */
 			ui->urlLineEdit->setText("https://api.openai.com/v1/chat/completions");
 			ui->bodyTextEdit->setText(R"({
-	"model": "gpt-3.5-turbo",
+	"model": "gpt-4o-mini",
 	"messages": [
 		{
 			"role": "system",

--- a/src/ui/RequestBuilder.cpp
+++ b/src/ui/RequestBuilder.cpp
@@ -193,7 +193,7 @@ RequestBuilder::RequestBuilder(url_source_request_data *request_data,
 			/* --------------------------------------------- */
 			ui->urlLineEdit->setText("https://api.openai.com/v1/chat/completions");
 			ui->bodyTextEdit->setText(R"({
-  "model": "gpt-4-vision-preview",
+  "model": "gpt-4o-mini",
   "messages": [
     {
       "role": "user",


### PR DESCRIPTION
Updated the GPT models in the preset list to use gpt-4o-mini which is cheaper and more capable and also supports vision.

gpt-4-vision-preview is no longer in use